### PR TITLE
Fix ClassCastException in RedundantDocCommentTagInspection

### DIFF
--- a/src/main/kotlin/com/funivan/idea/phpClean/inspections/redundantDocCommentTag/RedundantDocCommentTagInspection.kt
+++ b/src/main/kotlin/com/funivan/idea/phpClean/inspections/redundantDocCommentTag/RedundantDocCommentTagInspection.kt
@@ -53,7 +53,7 @@ class RedundantDocCommentTagInspection : PhpCleanInspection() {
                     val doc = tag.type.toStringResolved()
                     val declared = type.toStringResolved()
                     if (doc == declared) {
-                        val skip = (tag.firstPsiChild as PhpDocType?)?.canonicalText?.contains(Regex("[<\\]]+"))
+                        val skip = (tag.firstPsiChild as? PhpDocType)?.canonicalText?.contains(Regex("[<\\]]+"))
                         if (skip == false) {
                             holder.registerProblem(
                                     tag,


### PR DESCRIPTION
```
java.lang.ClassCastException: class com.jetbrains.php.lang.documentation.phpdoc.psi.impl.PhpDocVarImpl cannot be cast to class com.jetbrains.php.lang.documentation.phpdoc.psi.PhpDocType (com.jetbrains.php.lang.documentation.phpdoc.psi.impl.PhpDocVarImpl and com.jetbrains.php.lang.documentation.phpdoc.psi.PhpDocType are in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @1babe7c7)
	at com.funivan.idea.phpClean.inspections.redundantDocCommentTag.RedundantDocCommentTagInspection$buildVisitor$1.checkComment(RedundantDocCommentTagInspection.kt:56)
	at com.funivan.idea.phpClean.inspections.redundantDocCommentTag.RedundantDocCommentTagInspection$buildVisitor$1.visitPhpFunction(RedundantDocCommentTagInspection.kt:37)
	at com.funivan.idea.phpClean.inspections.redundantDocCommentTag.RedundantDocCommentTagInspection$buildVisitor$1.visitPhpMethod(RedundantDocCommentTagInspection.kt:25)
	at com.jetbrains.php.lang.psi.elements.impl.MethodImpl.accept(MethodImpl.java:93)
	at com.jetbrains.php.lang.psi.elements.impl.PhpPsiElementImpl.accept(PhpPsiElementImpl.java:73)
	at com.intellij.codeInspection.InspectionEngine.acceptElements(InspectionEngine.java:65)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.lambda$visitRestElementsAndCleanup$6(LocalInspectionsPass.java:319)
	at com.intellij.util.AstLoadingFilter.lambda$toComputable$2(AstLoadingFilter.java:168)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:126)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:115)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:110)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.lambda$visitRestElementsAndCleanup$7(LocalInspectionsPass.java:319)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:149)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:162)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1110)
	at com.intellij.concurrency.ApplierCompleter.lambda$wrapInReadActionAndIndicator$1(ApplierCompleter.java:105)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:629)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:581)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
	at com.jetbrains.rdserver.BackendProgressManager.executeProcessUnderProgress(BackendProgressManager.kt:75)
	at com.intellij.concurrency.ApplierCompleter.wrapInReadActionAndIndicator(ApplierCompleter.java:117)
	at com.intellij.concurrency.ApplierCompleter.lambda$compute$0(ApplierCompleter.java:96)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:170)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:182)
	at com.intellij.concurrency.ApplierCompleter.compute(ApplierCompleter.java:96)
	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:746)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```