### PR TITLE
#151 Fix PropertyCanBePrivate for promoted properties php8.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,14 +19,14 @@ jobs:
           echo "PLUGIN_CHANNEL=$(echo "${GITHUB_REF}" | grep -oE "[^-]+$" | grep -oE "^[a-z]+$")" >> $GITHUB_ENV
       - name: Configure Gradle environment variables
         run: |
-          echo "ORG_GRADLE_PROJECT_version=$(echo "${PLUGIN_VERSION}")" >> $GITHUB_ENV
+          echo "ORG_GRADLE_PROJECT_pluginVersion=$(echo "${PLUGIN_VERSION}")" >> $GITHUB_ENV
           echo "ORG_GRADLE_PROJECT_intellijPublishToken=${{ secrets.intellijPublishToken }}" >> $GITHUB_ENV
           echo "ORG_GRADLE_PROJECT_intellijPublishChannel=$(echo "${PLUGIN_CHANNEL}")" >> $GITHUB_ENV
       - name: Print environment variables
         run: |
           echo "PLUGIN_VERSION=$PLUGIN_VERSION"
           echo "PLUGIN_CHANNEL=$PLUGIN_CHANNEL"
-          echo "ORG_GRADLE_PROJECT_version=$ORG_GRADLE_PROJECT_version"
+          echo "ORG_GRADLE_PROJECT_pluginVersion=$ORG_GRADLE_PROJECT_version"
           echo "ORG_GRADLE_PROJECT_intellijPublishToken=$ORG_GRADLE_PROJECT_intellijPublishToken"
           echo "ORG_GRADLE_PROJECT_intellijPublishChannel=$ORG_GRADLE_PROJECT_intellijPublishChannel"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,13 +5,6 @@ on:
 jobs:
   test:
     name: Test
-    strategy:
-      matrix:
-        include:
-          - idea: "IU-2020.2"
-            php: "202.6397.115"
-          - idea: "IU-2020.2.3"
-            php: "202.7660.42"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -22,6 +15,3 @@ jobs:
       - uses: burrunan/gradle-cache-action@v1.5
         with:
           arguments: check buildPlugin
-        env:
-            ORG_GRADLE_PROJECT_ideaVersion: ${{ matrix.idea }}
-            ORG_GRADLE_PROJECT_phpPluginVersion: ${{ matrix.php }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 # PhpClean Changelog
 ## [Unreleased]
-
+### Changed
+ - #151 Fix property visibility inspection for php8.1
 ## [2022.10.22]
 ### Changed
 - #143 [Fixed] Check automatic string typecast on methods only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 <!-- Keep a Changelog guide -> https://keepachangelog.com -->
 
 # PhpClean Changelog
-## [Unreleased]
+## [2022.08.05]
 ### Changed
  - #151 Fix property visibility inspection for php8.1
+
 ## [2022.10.22]
 ### Changed
 - #143 [Fixed] Check automatic string typecast on methods only

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ platformVersion = 2022.1.4
 platformDownloadSources = true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = com.intellij.java, com.jetbrains.php:221.6008.13
+platformPlugins = com.intellij.java, com.jetbrains.php:221.6008.13, PsiViewer:221-SNAPSHOT
 
 # Opt-out flag for bundling Kotlin standard library.
 # See https://kotlinlang.org/docs/reference/using-gradle.html#dependency-on-the-standard-library for details.

--- a/src/main/kotlin/com/funivan/idea/phpClean/inspections/propertyCanBePrivate/PropertyCanBePrivateInspection.kt
+++ b/src/main/kotlin/com/funivan/idea/phpClean/inspections/propertyCanBePrivate/PropertyCanBePrivateInspection.kt
@@ -5,8 +5,10 @@ import com.funivan.idea.phpClean.qf.makeClassMemberPrivate.MakeClassMemberPrivat
 import com.funivan.idea.phpClean.spl.PhpCleanInspection
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElementVisitor
+import com.jetbrains.php.lang.psi.elements.Field
 import com.jetbrains.php.lang.psi.elements.PhpClass
 import com.jetbrains.php.lang.psi.elements.PhpModifierList
+import com.jetbrains.php.lang.psi.elements.impl.PhpPromotedFieldParameterImpl
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor
 
 class PropertyCanBePrivateInspection : PhpCleanInspection() {
@@ -18,15 +20,23 @@ class PropertyCanBePrivateInspection : PhpCleanInspection() {
                 if (constraint.match(target)) {
                     for (property in target.ownFields.filter { it.modifier.isProtected }) {
                         holder.registerProblem(
-                                property.nameIdentifier ?: property,
-                                "Property can be private",
-                                MakeClassMemberPrivateQF.create(
-                                        property.parent.firstChild as PhpModifierList?,
-                                        "Make property private"
-                                )
+                            property.nameIdentifier ?: property,
+                            "Property can be private",
+                            qf(property)
                         )
                     }
                 }
+            }
+
+            private fun qf(property: Field?): MakeClassMemberPrivateQF? {
+                val qf = when (property is PhpPromotedFieldParameterImpl) {
+                    true -> MakeClassMemberPrivateQF.create(property, "Make property private")
+                    false -> MakeClassMemberPrivateQF.create(
+                        property?.parent?.firstChild as? PhpModifierList,
+                        "Make property private"
+                    )
+                }
+                return qf
             }
         }
     }

--- a/src/main/kotlin/com/funivan/idea/phpClean/qf/makeClassMemberPrivate/MakeClassMemberPrivateQF.kt
+++ b/src/main/kotlin/com/funivan/idea/phpClean/qf/makeClassMemberPrivate/MakeClassMemberPrivateQF.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.SmartPsiElementPointer
 import com.jetbrains.php.lang.lexer.PhpTokenTypes
 import com.jetbrains.php.lang.psi.PhpPsiElementFactory
 import com.jetbrains.php.lang.psi.elements.PhpModifierList
+import com.jetbrains.php.lang.psi.elements.impl.PhpPromotedFieldParameterImpl
 
 class MakeClassMemberPrivateQF(
         private val pointer: SmartPsiElementPointer<PsiElement>,
@@ -26,6 +27,13 @@ class MakeClassMemberPrivateQF(
     }
 
     companion object {
+        fun create(element: PhpPromotedFieldParameterImpl, name: String) = element.node
+            .firstChildNode
+            ?.psi
+            ?.let {
+                MakeClassMemberPrivateQF(Pointer(it).create(), name)
+            }
+
         fun create(modifier: PhpModifierList?, name: String) = modifier
                 ?.node
                 ?.findChildByType(PhpTokenTypes.kwPROTECTED)

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/methodShouldBeFinal/MethodShouldBeFinalInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/methodShouldBeFinal/MethodShouldBeFinalInspectionTest.kt
@@ -1,9 +1,11 @@
 package com.funivan.idea.phpClean.inspections.methodShouldBeFinal
 
 import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
 
 class MethodShouldBeFinalInspectionTest : BaseInspectionTest() {
 
+    @Test
     fun testMethodShouldBeFinal() {
         assert(
                 MethodShouldBeFinalInspection(),
@@ -17,6 +19,28 @@ class MethodShouldBeFinalInspectionTest : BaseInspectionTest() {
         )
     }
 
+
+    @Test
+    fun testPhp81() {
+        assert(
+                MethodShouldBeFinalInspection(),
+                """<?php
+                    class CustomerDTO
+                    {
+                        public function <warning descr="Method should be final">test</warning>() : int{
+                            return 1;
+                        }
+                        public function __construct(
+                            public string ${'$'}name, 
+                            public string ${'$'}email, 
+                            public DateTimeImmutable ${'$'}birth_date,
+                        ) {}
+                    }
+                """
+        )
+    }
+
+    @Test
     fun testSkipFinalClass() {
         assert(
                 MethodShouldBeFinalInspection(),
@@ -28,6 +52,7 @@ class MethodShouldBeFinalInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testSkipInterface() {
         assert(
                 MethodShouldBeFinalInspection(),
@@ -39,6 +64,7 @@ class MethodShouldBeFinalInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testSkipAbstractMethod() {
         assert(
                 MethodShouldBeFinalInspection(),
@@ -50,6 +76,7 @@ class MethodShouldBeFinalInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testSkipMagicMethods() {
         assert(
                 MethodShouldBeFinalInspection(),
@@ -63,6 +90,7 @@ class MethodShouldBeFinalInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testSkipStaticMethod(){
         assert(
                 MethodShouldBeFinalInspection(),
@@ -73,6 +101,7 @@ class MethodShouldBeFinalInspectionTest : BaseInspectionTest() {
                 """
         )
     }
+    @Test
     fun testSkipPrivateMethods(){
         assert(
                 MethodShouldBeFinalInspection(),

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/propertyCanBePrivate/PropertyCanBePrivateInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/propertyCanBePrivate/PropertyCanBePrivateInspectionTest.kt
@@ -1,9 +1,30 @@
 package com.funivan.idea.phpClean.inspections.propertyCanBePrivate
 
 import com.funivan.idea.phpClean.BaseInspectionTest
-
+import kotlin.test.Test
 class PropertyCanBePrivateInspectionTest : BaseInspectionTest() {
 
+    @Test
+    fun testPhp81() {
+        assert(
+            PropertyCanBePrivateInspection(),
+            """<?php
+                    final class UserDTO {
+                        public function __construct(
+                            protected string <warning descr="Property can be private">${'$'}name</warning> 
+                        ) {}
+                    }
+                """,
+            """<?php
+                    final class UserDTO {
+                        public function __construct(
+                            private string ${'$'}name 
+                        ) {}
+                    }
+                """
+        )
+    }
+    @Test
     fun testCheckFinalClasses() {
         assert(
                 PropertyCanBePrivateInspection(),
@@ -20,6 +41,7 @@ class PropertyCanBePrivateInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testPropertyInExtensionClass() {
         assert(
                 PropertyCanBePrivateInspection(),
@@ -31,6 +53,7 @@ class PropertyCanBePrivateInspectionTest : BaseInspectionTest() {
                 """
         )
     }
+    @Test
     fun testPropertyInExtendedClass() {
         assert(
                 PropertyCanBePrivateInspection(),
@@ -43,6 +66,7 @@ class PropertyCanBePrivateInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testCheckPublicProperties() {
         assert(
                 PropertyCanBePrivateInspection(),
@@ -54,6 +78,7 @@ class PropertyCanBePrivateInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testCheckWithTypeDefinition() {
         assert(
                 PropertyCanBePrivateInspection(),
@@ -69,6 +94,7 @@ class PropertyCanBePrivateInspectionTest : BaseInspectionTest() {
                 """
         )
     }
+    @Test
     fun testCheckTrait() {
         assert(
                 PropertyCanBePrivateInspection(),
@@ -80,6 +106,7 @@ class PropertyCanBePrivateInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testCheckAbstractClass() {
         assert(
                 PropertyCanBePrivateInspection(),


### PR DESCRIPTION
Php 8.1 has a nice feature: promotedproperties. In the AST structure it is slightly different than the regular properties
```php
final class UserDTO {
  public function __construct(
    protected string $name;
   ) {}
 }
```
Fixes the issue #151 