### PR TITLE
#156 Skip Virtual type check for generic types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [2022.08.05]
 ### Changed
  - #151 Fix property visibility inspection for php8.1
+ - #156 Skip Virtual type check for generic types
 
 ## [2022.10.22]
 ### Changed

--- a/src/main/kotlin/com/funivan/idea/phpClean/inspections/virtualTypeCheck/VirtualTypeCheckInspection.kt
+++ b/src/main/kotlin/com/funivan/idea/phpClean/inspections/virtualTypeCheck/VirtualTypeCheckInspection.kt
@@ -22,7 +22,7 @@ class VirtualTypeCheckInspection : PhpCleanInspection() {
                     val variableType = tag.children.firstOrNull { it is PhpDocType }
                     if (variable is PhpDocVariable && variableType is PhpDocType) {
                         val type = variableType.type
-                        if (!type.isAmbiguous && type.types.size == 1) {
+                        if (!type.isAmbiguous && type.types.size == 1 && !variableType.text.contains("<")) {
                             val plain = type.toStringResolved()
                             if (!PhpType.isPluralType(plain) && !PhpType.isNotExtendablePrimitiveType(plain)) {
                                 val index = PhpIndex.getInstance(variableType.project)

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/assignMisused/AssignMisusedInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/assignMisused/AssignMisusedInspectionTest.kt
@@ -1,13 +1,15 @@
 package com.funivan.idea.phpClean.inspections.assignMisused
 
 import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
 
 class AssignMisusedInspectionTest : BaseInspectionTest() {
 
+    @Test
     fun testValidCase() {
         assert(
-                AssignMisusedInspection(),
-                """<?php
+            AssignMisusedInspection(),
+            """<?php
                     ${'$'}b = 123;
                     ${'$'}c == ${'$'}b;
                     ${'$'}a = ${'b'}===1;
@@ -15,10 +17,11 @@ class AssignMisusedInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testComparisonAndAssignment() {
         assert(
-                AssignMisusedInspection(),
-                """<?php
+            AssignMisusedInspection(),
+            """<?php
                     ${'$'}c = ${'$'}b = ${'$'}f;
                     do{} while (<warning descr="Assignment and comparison operators used in one statement">false !== ${'$'}a = ${'$'}b</warning>);
                     do{} while (<warning descr="Assignment and comparison operators used in one statement">false !== ${'$'}a = ${'$'}b</warning>);
@@ -32,10 +35,11 @@ class AssignMisusedInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testMultiplyOperator() {
         assert(
-                AssignMisusedInspection(),
-                """<?php
+            AssignMisusedInspection(),
+            """<?php
                     ${'$'}i = ${'$'}j = ${'$'}f = 0;
                     ${'$'}f = ${'$'}j * ${'$'}f + ${'$'}i;
                     ${'$'}j = ${'$'}k !== ${'$'}l;

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/classNameCollision/ClassNameCollisionInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/classNameCollision/ClassNameCollisionInspectionTest.kt
@@ -1,13 +1,15 @@
 package com.funivan.idea.phpClean.inspections.classNameCollision
 
 import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
 
 class ClassNameCollisionInspectionTest : BaseInspectionTest() {
 
+    @Test
     fun testClassNameCollision() {
         assert(
-                ClassNameCollisionInspection(),
-                """<?php
+            ClassNameCollisionInspection(),
+            """<?php
                     namespace App {
                       class <warning descr="Class name collision with \Cli\User">User</warning>{};
                     }
@@ -18,10 +20,11 @@ class ClassNameCollisionInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testCollisionInGlobalNamespace() {
         assert(
-                ClassNameCollisionInspection(),
-                """<?php
+            ClassNameCollisionInspection(),
+            """<?php
                     namespace {
                       class <warning descr="Class name collision with \App\User">User</warning>{};
                     }

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/deprecatedDocTag/DeprecatedDocTagInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/deprecatedDocTag/DeprecatedDocTagInspectionTest.kt
@@ -1,34 +1,37 @@
 package com.funivan.idea.phpClean.inspections.deprecatedDocTag
 
 import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
 
 class DeprecatedDocTagInspectionTest : BaseInspectionTest() {
 
+    @Test
     fun testDeprecatedTag() {
         val inspection = DeprecatedDocTagInspection()
         inspection.tags.add("property")
         assert(
-                inspection,
-                """<?php
+            inspection,
+            """<?php
                     # Some comment
                     /**
                      * <warning descr="Deprecated tag">@property ${'$'}name</warning>
                      */
                      class User{}
                 """,
-                """<?php
+            """<?php
                     # Some comment
 class User{}
                 """
         )
     }
 
+    @Test
     fun testNegativeDeprecation() {
         val inspection = DeprecatedDocTagInspection()
         inspection.tags.addAll(listOf("property-read", "method"))
         assert(
-                inspection,
-                """<?php
+            inspection,
+            """<?php
                     /**
                      * @property ${'$'}user
                      * @property-write ${'$'}id
@@ -36,7 +39,7 @@ class User{}
                      * <warning descr="Deprecated tag">@method user()</warning>
                      */
                 """,
-                """<?php
+            """<?php
                     /**
                      * @property ${'$'}user
                      * @property-write ${'$'}id

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/globalVariableUsage/GlobalVariableUsageInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/globalVariableUsage/GlobalVariableUsageInspectionTest.kt
@@ -1,13 +1,15 @@
 package com.funivan.idea.phpClean.inspections.globalVariableUsage
 
 import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
 
 class GlobalVariableUsageInspectionTest : BaseInspectionTest() {
 
+    @Test
     fun testGlobalVariableUsage() {
         assert(
-                GlobalVariableUsageInspection(),
-                """<?php
+            GlobalVariableUsageInspection(),
+            """<?php
                     echo <warning descr="Global variable usage">${'$'}_GET</warning>['name'];
                 """
         )

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/methodCanBePrivate/MethodCanBePrivateInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/methodCanBePrivate/MethodCanBePrivateInspectionTest.kt
@@ -1,18 +1,20 @@
 package com.funivan.idea.phpClean.inspections.methodCanBePrivate
 
 import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
 
 class MethodCanBePrivateInspectionTest : BaseInspectionTest() {
 
+    @Test
     fun testFindMethodsThatCanBePrivate() {
         assert(
-                MethodCanBePrivateInspection(),
-                """<?php
+            MethodCanBePrivateInspection(),
+            """<?php
                 final class User {
                   protected function <warning descr="Method can be private">name</warning>() {}
                 }
                 """,
-                """<?php
+            """<?php
                 final class User {
                   private function name() {}
                 }
@@ -20,10 +22,11 @@ class MethodCanBePrivateInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testFindMethodsInNonFinalClass() {
         assert(
-                MethodCanBePrivateInspection(),
-                """<?php
+            MethodCanBePrivateInspection(),
+            """<?php
                 class A {
                   protected function name() {}
                 }
@@ -31,10 +34,11 @@ class MethodCanBePrivateInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testFindMethodsInClassWithExtends() {
         assert(
-                MethodCanBePrivateInspection(),
-                """<?php
+            MethodCanBePrivateInspection(),
+            """<?php
                 class Test{}
                 final class Uid extends Test {
                   protected function id() {}
@@ -43,10 +47,11 @@ class MethodCanBePrivateInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testCheckPublicMethod() {
         assert(
-                MethodCanBePrivateInspection(),
-                """<?php
+            MethodCanBePrivateInspection(),
+            """<?php
                 final class Id {
                   public function __construct() {}
                   public function size() {}

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/methodShouldBeFinal/MethodShouldBeFinalInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/methodShouldBeFinal/MethodShouldBeFinalInspectionTest.kt
@@ -8,8 +8,8 @@ class MethodShouldBeFinalInspectionTest : BaseInspectionTest() {
     @Test
     fun testMethodShouldBeFinal() {
         assert(
-                MethodShouldBeFinalInspection(),
-                """<?php
+            MethodShouldBeFinalInspection(),
+            """<?php
                 class User{
                  public function <warning descr="Method should be final">name</warning>() : string {
                   return "";
@@ -23,8 +23,8 @@ class MethodShouldBeFinalInspectionTest : BaseInspectionTest() {
     @Test
     fun testPhp81() {
         assert(
-                MethodShouldBeFinalInspection(),
-                """<?php
+            MethodShouldBeFinalInspection(),
+            """<?php
                     class CustomerDTO
                     {
                         public function <warning descr="Method should be final">test</warning>() : int{
@@ -43,8 +43,8 @@ class MethodShouldBeFinalInspectionTest : BaseInspectionTest() {
     @Test
     fun testSkipFinalClass() {
         assert(
-                MethodShouldBeFinalInspection(),
-                """<?php
+            MethodShouldBeFinalInspection(),
+            """<?php
                 final class A{
                  public function id() : string{ return ""; }
                 }
@@ -55,8 +55,8 @@ class MethodShouldBeFinalInspectionTest : BaseInspectionTest() {
     @Test
     fun testSkipInterface() {
         assert(
-                MethodShouldBeFinalInspection(),
-                """<?php
+            MethodShouldBeFinalInspection(),
+            """<?php
                 interface Name{
                  public function short() : string;
                 }
@@ -67,8 +67,8 @@ class MethodShouldBeFinalInspectionTest : BaseInspectionTest() {
     @Test
     fun testSkipAbstractMethod() {
         assert(
-                MethodShouldBeFinalInspection(),
-                """<?php
+            MethodShouldBeFinalInspection(),
+            """<?php
                 abstract class UID {
                   abstract public function print() : void;
                 }
@@ -79,8 +79,8 @@ class MethodShouldBeFinalInspectionTest : BaseInspectionTest() {
     @Test
     fun testSkipMagicMethods() {
         assert(
-                MethodShouldBeFinalInspection(),
-                """<?php
+            MethodShouldBeFinalInspection(),
+            """<?php
                 class Dealer {
                   public function __construct(){}
                   public function __destruct(){}
@@ -91,21 +91,22 @@ class MethodShouldBeFinalInspectionTest : BaseInspectionTest() {
     }
 
     @Test
-    fun testSkipStaticMethod(){
+    fun testSkipStaticMethod() {
         assert(
-                MethodShouldBeFinalInspection(),
-                """<?php
+            MethodShouldBeFinalInspection(),
+            """<?php
                 class Dealer {
                   public static function show(){}
                 }
                 """
         )
     }
+
     @Test
-    fun testSkipPrivateMethods(){
+    fun testSkipPrivateMethods() {
         assert(
-                MethodShouldBeFinalInspection(),
-                """<?php
+            MethodShouldBeFinalInspection(),
+            """<?php
                 class Dealer {
                   private function show(){}
                 }

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/methodVisibility/MethodVisibilityInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/methodVisibility/MethodVisibilityInspectionTest.kt
@@ -1,13 +1,15 @@
 package com.funivan.idea.phpClean.inspections.methodVisibility
 
 import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
 
 class MethodVisibilityInspectionTest : BaseInspectionTest() {
 
+    @Test
     fun testProtectedMethod() {
         assert(
-                MethodVisibilityInspection(),
-                """<?php
+            MethodVisibilityInspection(),
+            """<?php
                 class User {
                   protected function <weak_warning descr="Do not write protected methods. Only public or private">name</weak_warning>() : string {}
                   public function id() : string {}

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/missingParameterType/MissingParameterTypeDeclarationInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/missingParameterType/MissingParameterTypeDeclarationInspectionTest.kt
@@ -1,13 +1,15 @@
 package com.funivan.idea.phpClean.inspections.missingParameterType
 
 import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
 
 class MissingParameterTypeDeclarationInspectionTest : BaseInspectionTest() {
 
+    @Test
     fun testMissingParameterType() {
         assert(
-                MissingParameterTypeDeclarationInspection(),
-                """<?php
+            MissingParameterTypeDeclarationInspection(),
+            """<?php
                 class User{
                     function withName(<warning descr="Missing parameter type">${'$'}name</warning>){}
                 }
@@ -15,10 +17,11 @@ class MissingParameterTypeDeclarationInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testMethodWithParameterTypes() {
         assert(
-                MissingParameterTypeDeclarationInspection(),
-                """<?php
+            MissingParameterTypeDeclarationInspection(),
+            """<?php
                 class User{
                     function withName(string ${'$'}name){}
                 }
@@ -26,10 +29,11 @@ class MissingParameterTypeDeclarationInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testIgnoreParameter() {
         assert(
-                MissingParameterTypeDeclarationInspection(),
-                """<?php
+            MissingParameterTypeDeclarationInspection(),
+            """<?php
                 class User{
                     /**
                      * @param string ${'$'}name @Suppress(MissingParameterTypeDeclarationInspection)
@@ -40,20 +44,23 @@ class MissingParameterTypeDeclarationInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testInvalidPsi() {
         assert(
-                MissingParameterTypeDeclarationInspection(),
-                """<?php
+            MissingParameterTypeDeclarationInspection(),
+            """<?php
                 class User{
                     abstract function withId(<error descr="Expected: variable">,</error><error descr="Unexpected: )">)</error>
                 }
                 """
         )
     }
+
+    @Test
     fun testSkipOverwrittenMethods() {
         assert(
-                MissingParameterTypeDeclarationInspection(),
-                """<?php
+            MissingParameterTypeDeclarationInspection(),
+            """<?php
                  interface Uid{
                     function hash(<warning descr="Missing parameter type">${'$'}salt</warning>);
                  }

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/missingReturnType/MissingReturnTypeInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/missingReturnType/MissingReturnTypeInspectionTest.kt
@@ -1,13 +1,15 @@
 package com.funivan.idea.phpClean.inspections.missingReturnType
 
 import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
 
 class MissingReturnTypeInspectionTest : BaseInspectionTest() {
 
+    @Test
     fun testMethodWithoutReturnType() {
         assert(
-                MissingReturnTypeInspection(),
-                """<?php
+            MissingReturnTypeInspection(),
+            """<?php
                 class Action {
                  /** @return void */
                   protected function <warning descr="Missing return type">hide</warning>(){}
@@ -15,10 +17,12 @@ class MissingReturnTypeInspectionTest : BaseInspectionTest() {
                 """
         )
     }
+
+    @Test
     fun testWithoutReturnType() {
         assert(
-                MissingReturnTypeInspection(),
-                """<?php
+            MissingReturnTypeInspection(),
+            """<?php
                 class Action {
                   protected function hide() : void {}
                 }
@@ -26,10 +30,11 @@ class MissingReturnTypeInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testMagicMethods() {
         assert(
-                MissingReturnTypeInspection(),
-                """<?php
+            MissingReturnTypeInspection(),
+            """<?php
                 class UserName {
                   protected function __construct(){}
                   protected function __clone(){}

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/parentPropertyDeprecated/ParentPropertyDeprecatedInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/parentPropertyDeprecated/ParentPropertyDeprecatedInspectionTest.kt
@@ -1,13 +1,14 @@
 package com.funivan.idea.phpClean.inspections.parentPropertyDeprecated
 
 import com.funivan.idea.phpClean.BaseInspectionTest
-import com.funivan.idea.phpClean.inspections.parentPropertyDeprecated.ParentPropertyDeprecatedInspection
+import kotlin.test.Test
 
 class ParentPropertyDeprecatedInspectionTest : BaseInspectionTest() {
+    @Test
     fun testDeprecatedParentProperty() {
         assert(
-                ParentPropertyDeprecatedInspection(),
-                """
+            ParentPropertyDeprecatedInspection(),
+            """
                     <?php
                     class A {
                         /** @deprecated */
@@ -20,10 +21,11 @@ class ParentPropertyDeprecatedInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testAllPropertiesAreDeprecated() {
         assert(
-                ParentPropertyDeprecatedInspection(),
-                """
+            ParentPropertyDeprecatedInspection(),
+            """
                     <?php
                     class A {
                         /** @deprecated */
@@ -37,10 +39,11 @@ class ParentPropertyDeprecatedInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testNonDeprecatedProperties() {
         assert(
-                ParentPropertyDeprecatedInspection(),
-                """
+            ParentPropertyDeprecatedInspection(),
+            """
                     <?php
                     class A { public ${'$'}name; }
                     class B extends A{ public ${'$'}name; }

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/propertyAnnotation/PropertyAnnotationInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/propertyAnnotation/PropertyAnnotationInspectionTest.kt
@@ -1,13 +1,14 @@
 package com.funivan.idea.phpClean.inspections.propertyAnnotation
 
 import com.funivan.idea.phpClean.BaseInspectionTest
-
+import kotlin.test.Test
 
 class PropertyAnnotationInspectionTest : BaseInspectionTest() {
+    @Test
     fun testPropertyIsNotAnnotatedCorrectly() {
         assert(
-                PropertyAnnotationInspection(),
-                """
+            PropertyAnnotationInspection(),
+            """
                     <?php
                     class A {
                         /** @var string[] */
@@ -17,10 +18,11 @@ class PropertyAnnotationInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testPropertiesWithoutDocumentation() {
         assert(
-                PropertyAnnotationInspection(),
-                """
+            PropertyAnnotationInspection(),
+            """
                     <?php
                     class A {
                      private ${'$'}name;
@@ -34,10 +36,11 @@ class PropertyAnnotationInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testPropertyWithCorrectDocumentation() {
         assert(
-                PropertyAnnotationInspection(),
-                """
+            PropertyAnnotationInspection(),
+            """
                     <?php
                     class A {
                         /** @var string[]|null */
@@ -52,10 +55,11 @@ class PropertyAnnotationInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testAnnotateOwnFieldsOnly() {
         assert(
-                PropertyAnnotationInspection(),
-                """
+            PropertyAnnotationInspection(),
+            """
                     <?php
                     class B extends A {
                         /**
@@ -71,10 +75,11 @@ class PropertyAnnotationInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testPropertiesInFinalClass() {
         assert(
-                PropertyAnnotationInspection(),
-                """
+            PropertyAnnotationInspection(),
+            """
                     <?php
                     final class A {
                      /** @var string[]*/
@@ -86,10 +91,11 @@ class PropertyAnnotationInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testPropertiesInFinalClassWithExtends() {
         assert(
-                PropertyAnnotationInspection(),
-                """
+            PropertyAnnotationInspection(),
+            """
                     <?php
                     final class B extends C{
                      /** @var string */
@@ -101,10 +107,11 @@ class PropertyAnnotationInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testPrivatePropertiesInClassesWithoutConstructor() {
         assert(
-                PropertyAnnotationInspection(),
-                """
+            PropertyAnnotationInspection(),
+            """
                     <?php
                     class A {
                         /** @var string */
@@ -114,10 +121,11 @@ class PropertyAnnotationInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testPrivatePropertyNotInitializedInTheConstructor() {
         assert(
-                PropertyAnnotationInspection(),
-                """
+            PropertyAnnotationInspection(),
+            """
                     <?php
                     class A {
                         /**
@@ -129,10 +137,11 @@ class PropertyAnnotationInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testWithParentConstructor() {
         assert(
-                PropertyAnnotationInspection(),
-                """
+            PropertyAnnotationInspection(),
+            """
                     <?php
                     class A {
                      public function __construct(){
@@ -150,10 +159,11 @@ class PropertyAnnotationInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testWithoutInitInConstructor() {
         assert(
-                PropertyAnnotationInspection(),
-                """
+            PropertyAnnotationInspection(),
+            """
                     <?php
                     class A {
                         /**
@@ -171,10 +181,11 @@ class PropertyAnnotationInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testWithInitInConstructor() {
         assert(
-                PropertyAnnotationInspection(),
-                """
+            PropertyAnnotationInspection(),
+            """
                     <?php
                     class A {
                         /**

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/propertyCanBePrivate/PropertyCanBePrivateInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/propertyCanBePrivate/PropertyCanBePrivateInspectionTest.kt
@@ -2,6 +2,7 @@ package com.funivan.idea.phpClean.inspections.propertyCanBePrivate
 
 import com.funivan.idea.phpClean.BaseInspectionTest
 import kotlin.test.Test
+
 class PropertyCanBePrivateInspectionTest : BaseInspectionTest() {
 
     @Test
@@ -24,16 +25,17 @@ class PropertyCanBePrivateInspectionTest : BaseInspectionTest() {
                 """
         )
     }
+
     @Test
     fun testCheckFinalClasses() {
         assert(
-                PropertyCanBePrivateInspection(),
-                """<?php
+            PropertyCanBePrivateInspection(),
+            """<?php
                 final class User {
                   protected <warning descr="Property can be private">${'$'}user</warning>;
                 }
                 """,
-                """<?php
+            """<?php
                 final class User {
                   private ${'$'}user;
                 }
@@ -44,8 +46,8 @@ class PropertyCanBePrivateInspectionTest : BaseInspectionTest() {
     @Test
     fun testPropertyInExtensionClass() {
         assert(
-                PropertyCanBePrivateInspection(),
-                """<?php
+            PropertyCanBePrivateInspection(),
+            """<?php
                 class A2 {
                   protected ${'$'}name;
                 }
@@ -53,11 +55,12 @@ class PropertyCanBePrivateInspectionTest : BaseInspectionTest() {
                 """
         )
     }
+
     @Test
     fun testPropertyInExtendedClass() {
         assert(
-                PropertyCanBePrivateInspection(),
-                """<?php
+            PropertyCanBePrivateInspection(),
+            """<?php
                 class A1{}
                 class B1 extends A1 {
                   protected ${'$'}name;
@@ -69,8 +72,8 @@ class PropertyCanBePrivateInspectionTest : BaseInspectionTest() {
     @Test
     fun testCheckPublicProperties() {
         assert(
-                PropertyCanBePrivateInspection(),
-                """<?php
+            PropertyCanBePrivateInspection(),
+            """<?php
                 final class Id {
                   public array ${'$'}user;
                 }
@@ -81,24 +84,25 @@ class PropertyCanBePrivateInspectionTest : BaseInspectionTest() {
     @Test
     fun testCheckWithTypeDefinition() {
         assert(
-                PropertyCanBePrivateInspection(),
-                """<?php
+            PropertyCanBePrivateInspection(),
+            """<?php
                 class Id {
                   protected array <warning descr="Property can be private">${'$'}user</warning>;
                 }
                 """,
-                """<?php
+            """<?php
                 class Id {
                   private array ${'$'}user;
                 }
                 """
         )
     }
+
     @Test
     fun testCheckTrait() {
         assert(
-                PropertyCanBePrivateInspection(),
-                """<?php
+            PropertyCanBePrivateInspection(),
+            """<?php
                 trait Number {
                   protected int ${'$'}val;
                 }
@@ -109,8 +113,8 @@ class PropertyCanBePrivateInspectionTest : BaseInspectionTest() {
     @Test
     fun testCheckAbstractClass() {
         assert(
-                PropertyCanBePrivateInspection(),
-                """<?php
+            PropertyCanBePrivateInspection(),
+            """<?php
                 abstract class Str {
                   protected ${'$'}fast;
                 }

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/redundantDocCommentTag/RedundantDocCommentTagInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/redundantDocCommentTag/RedundantDocCommentTagInspectionTest.kt
@@ -1,28 +1,32 @@
 package com.funivan.idea.phpClean.inspections.redundantDocCommentTag
 
 import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
 
 class RedundantDocCommentTagInspectionTest : BaseInspectionTest() {
+    @Test
     fun testRedundantReturnType() {
         assert(
-                RedundantDocCommentTagInspection(),
-                """
+            RedundantDocCommentTagInspection(),
+            """
                     <?php
                      /**
                       *<warning descr="Redundant PhpDoc tag">@return void</warning>
                       */
                      function show(string ${'$'}message):void {}
                     """,
-                """
+            """
                     <?php
                     function show(string ${'$'}message):void {}
                     """
         )
     }
+
+    @Test
     fun testRedundantReturnTypeWithNonEmptyComment() {
         assert(
-                RedundantDocCommentTagInspection(),
-                """
+            RedundantDocCommentTagInspection(),
+            """
                     <?php
                      /**
                       * Hello world
@@ -30,7 +34,7 @@ class RedundantDocCommentTagInspectionTest : BaseInspectionTest() {
                       */
                      function show(string ${'$'}message):void {}
                     """,
-                """
+            """
                     <?php
                      /**
                       * Hello world
@@ -40,10 +44,11 @@ class RedundantDocCommentTagInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testRedundantParameterTag() {
         assert(
-                RedundantDocCommentTagInspection(),
-                """
+            RedundantDocCommentTagInspection(),
+            """
                     <?php
                      /**
                       *<warning descr="Redundant PhpDoc tag">@param string ${'$'}message</warning>
@@ -51,7 +56,7 @@ class RedundantDocCommentTagInspectionTest : BaseInspectionTest() {
                       */
                      function show(int ${'$'}a, string ${'$'}message):void {}
                     """,
-                """
+            """
                     <?php
                      /**
                       * @param string ${'$'}test
@@ -61,10 +66,11 @@ class RedundantDocCommentTagInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testRedundantParameterTagWithClassFQN() {
         assert(
-                RedundantDocCommentTagInspection(),
-                """
+            RedundantDocCommentTagInspection(),
+            """
                     <?php
                     class A{
                      /**
@@ -77,10 +83,11 @@ class RedundantDocCommentTagInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testReturnMultipleTypes() {
         assert(
-                RedundantDocCommentTagInspection(),
-                """
+            RedundantDocCommentTagInspection(),
+            """
                     <?php
                      /**
                       * @return \Generator|string[]
@@ -90,10 +97,11 @@ class RedundantDocCommentTagInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testCheckEmptyTag() {
         assert(
-                RedundantDocCommentTagInspection(),
-                """
+            RedundantDocCommentTagInspection(),
+            """
                     <?php
                      /**
                       * @return  
@@ -102,10 +110,12 @@ class RedundantDocCommentTagInspectionTest : BaseInspectionTest() {
                     """
         )
     }
+
+    @Test
     fun testCheckNullableReturnType() {
         assert(
-                RedundantDocCommentTagInspection(),
-                """
+            RedundantDocCommentTagInspection(),
+            """
                     <?php
                      /**
                       *<warning descr="Redundant PhpDoc tag">@return bool|null</warning>
@@ -115,10 +125,11 @@ class RedundantDocCommentTagInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testCheckNullableParameterType() {
         assert(
-                RedundantDocCommentTagInspection(),
-                """
+            RedundantDocCommentTagInspection(),
+            """
                     <?php
                      /**
                       *<warning descr="Redundant PhpDoc tag">@param stdClass|null ${'$'}o</warning>
@@ -128,10 +139,11 @@ class RedundantDocCommentTagInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testRedundantFieldTag() {
         assert(
-                RedundantDocCommentTagInspection(),
-                """
+            RedundantDocCommentTagInspection(),
+            """
                     <?php
                     class PhpClean {
                         /**
@@ -143,10 +155,11 @@ class RedundantDocCommentTagInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testFieldTagWithClassFQN() {
         assert(
-                RedundantDocCommentTagInspection(),
-                """
+            RedundantDocCommentTagInspection(),
+            """
                     <?php
                     class PhpClean {
                         /**
@@ -158,10 +171,11 @@ class RedundantDocCommentTagInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testFieldTagWithMultipleTypes() {
         assert(
-                RedundantDocCommentTagInspection(),
-                """
+            RedundantDocCommentTagInspection(),
+            """
                     <?php
                     class PhpClean {
                         /**
@@ -173,10 +187,11 @@ class RedundantDocCommentTagInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testFieldWithEmptyTag() {
         assert(
-                RedundantDocCommentTagInspection(),
-                """
+            RedundantDocCommentTagInspection(),
+            """
                     <?php
                     class PhpClean {
                         /**
@@ -188,10 +203,11 @@ class RedundantDocCommentTagInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testCheckNullableFieldType() {
         assert(
-                RedundantDocCommentTagInspection(),
-                """
+            RedundantDocCommentTagInspection(),
+            """
                     <?php
                     class PhpClean {
                         /**
@@ -203,10 +219,11 @@ class RedundantDocCommentTagInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testGenericType() {
         assert(
-                RedundantDocCommentTagInspection(),
-                """
+            RedundantDocCommentTagInspection(),
+            """
                     <?php
                     class PhpClean {
                      /**

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspectionTest.kt
@@ -1,12 +1,14 @@
 package com.funivan.idea.phpClean.inspections.toStringCall
 
 import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
 
 class ToStringCallInspectionTest : BaseInspectionTest() {
+    @Test
     fun testMethodCall() {
         assert(
-                ToStringCallInspection(),
-                """
+            ToStringCallInspection(),
+            """
                     <?php
                     class Hello {
                       public function randomize(): self { /* .. */return ${'$'}this; }
@@ -14,7 +16,7 @@ class ToStringCallInspectionTest : BaseInspectionTest() {
                     }
                     echo <warning descr="Deprecated __toString call">(new Hello())->randomize()</warning>;
                     """,
-                """
+            """
                     <?php
                     class Hello {
                       public function randomize(): self { /* .. */return ${'$'}this; }
@@ -25,19 +27,19 @@ class ToStringCallInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testConcatenation() {
         assert(
-                ToStringCallInspection(),
-                """
+            ToStringCallInspection(),
+            """
                     <?php
                     class Hello {
                       public function randomize(): self { /* .. */return ${'$'}this; }
                       public function __toString(){ echo 'Hi'; }
                     }
                      ${'$'}phrase = 'Hi ' . <warning descr="Deprecated __toString call">(new Hello())->randomize()</warning>;
-                    """
-                ,
-                """
+                    """,
+            """
                     <?php
                     class Hello {
                       public function randomize(): self { /* .. */return ${'$'}this; }
@@ -48,10 +50,11 @@ class ToStringCallInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testManualTypeCasting() {
         assert(
-                ToStringCallInspection(),
-                """
+            ToStringCallInspection(),
+            """
                     <?php
                     class Hello {
                       public function randomize(): self { /* .. */return ${'$'}this; }
@@ -63,10 +66,11 @@ class ToStringCallInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testNullableString() {
         assert(
-                ToStringCallInspection(),
-                """
+            ToStringCallInspection(),
+            """
                     <?php
                      class A{
                       function test(): ?string{ return null; }
@@ -76,10 +80,11 @@ class ToStringCallInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testNewObject() {
         assert(
-                ToStringCallInspection(),
-                """
+            ToStringCallInspection(),
+            """
                     <?php
                     class Hello {
                       public function __toString(){ echo 'Hi'; }
@@ -87,7 +92,7 @@ class ToStringCallInspectionTest : BaseInspectionTest() {
                     echo <warning descr="Deprecated __toString call">new Hello()</warning>;
                     ${'$'}phrase = <warning descr="Deprecated __toString call">new Hello()</warning> . ' there';
                     """,
-                """
+            """
                     <?php
                     class Hello {
                       public function __toString(){ echo 'Hi'; }
@@ -98,10 +103,11 @@ class ToStringCallInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testMethodStringReturned() {
         assert(
-                ToStringCallInspection(),
-                """
+            ToStringCallInspection(),
+            """
                     <?php
                     class Hello {
                       public function str():string{ return 'Hi'; }
@@ -119,10 +125,11 @@ class ToStringCallInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testStaticMethod() {
         assert(
-                ToStringCallInspection(),
-                """
+            ToStringCallInspection(),
+            """
                     <?php
                     class someClass {
                      public function __toString(){
@@ -132,7 +139,7 @@ class ToStringCallInspectionTest : BaseInspectionTest() {
                     }
                     echo <warning descr="Deprecated __toString call">SomeClass::create()</warning>;
                     """,
-                """
+            """
                     <?php
                     class someClass {
                      public function __toString(){

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspectionTestFunction.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspectionTestFunction.kt
@@ -1,12 +1,14 @@
 package com.funivan.idea.phpClean.inspections.toStringCall
 
 import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
 
 class ToStringCallInspectionTestFunction : BaseInspectionTest() {
+    @Test
     fun testFunctionCall() {
         assert(
-                ToStringCallInspection(),
-                """
+            ToStringCallInspection(),
+            """
                     <?php
                     class Phrase {
                       public function __toString(){ echo 'Hello'; }

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspectionTestTypeCast.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspectionTestTypeCast.kt
@@ -1,12 +1,14 @@
 package com.funivan.idea.phpClean.inspections.toStringCall
 
 import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
 
 class ToStringCallInspectionTestTypeCast : BaseInspectionTest() {
+    @Test
     fun testMethodTypeCast() {
         assert(
-                ToStringCallInspection(),
-                """
+            ToStringCallInspection(),
+            """
                     <?php
                     class Hello {
                       public function randomize(): self { /* .. */return ${'$'}this; }
@@ -18,10 +20,11 @@ class ToStringCallInspectionTestTypeCast : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testVariableTypeCast() {
         assert(
-                ToStringCallInspection(),
-                """
+            ToStringCallInspection(),
+            """
                     <?php
                     ${'$'}a = "";
                      echo (string) ${'$'}a;

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspectionTestVariable.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspectionTestVariable.kt
@@ -1,12 +1,14 @@
 package com.funivan.idea.phpClean.inspections.toStringCall
 
 import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
 
 class ToStringCallInspectionTestVariable : BaseInspectionTest() {
+    @Test
     fun testVariableEchoContext() {
         assert(
-                ToStringCallInspection(),
-                """
+            ToStringCallInspection(),
+            """
                     <?php
                     class Hello {
                       public function __toString(){ echo 'Hi'; }
@@ -18,10 +20,11 @@ class ToStringCallInspectionTestVariable : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testShortTagEcho() {
         assert(
-                ToStringCallInspection(),
-                """
+            ToStringCallInspection(),
+            """
                     <?php
                     class Hello {
                       public function __toString(){ echo 'Hi'; }
@@ -33,10 +36,11 @@ class ToStringCallInspectionTestVariable : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testVariableComparison() {
         assert(
-                ToStringCallInspection(),
-                """
+            ToStringCallInspection(),
+            """
                     <?php
                     class Hello {
                       public function __toString(){ echo 'Hi'; }

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/virtualTypeCheck/VirtualTypeCheckInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/virtualTypeCheck/VirtualTypeCheckInspectionTest.kt
@@ -1,8 +1,10 @@
 package com.funivan.idea.phpClean.inspections.virtualTypeCheck
 
 import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
 
 class VirtualTypeCheckInspectionTest : BaseInspectionTest() {
+    @Test
     fun testUseAssert() {
         assert(
                 VirtualTypeCheckInspection(),
@@ -13,6 +15,7 @@ class VirtualTypeCheckInspectionTest : BaseInspectionTest() {
                 """
         )
     }
+    @Test
     fun testUseAssertWithInterface() {
         assert(
                 VirtualTypeCheckInspection(),
@@ -24,6 +27,7 @@ class VirtualTypeCheckInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testIgnoreArray() {
         assert(
                 VirtualTypeCheckInspection(),
@@ -33,7 +37,7 @@ class VirtualTypeCheckInspectionTest : BaseInspectionTest() {
                 """
         )
     }
-
+    @Test
     fun testSkipPrimitiveTypes() {
         assert(
                 VirtualTypeCheckInspection(),
@@ -48,6 +52,7 @@ class VirtualTypeCheckInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testUnionType() {
         assert(
                 VirtualTypeCheckInspection(),
@@ -58,6 +63,7 @@ class VirtualTypeCheckInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testFunctionParam() {
         assert(
                 VirtualTypeCheckInspection(),
@@ -71,6 +77,7 @@ class VirtualTypeCheckInspectionTest : BaseInspectionTest() {
         )
     }
 
+    @Test
     fun testReverseFormat() {
         assert(
                 VirtualTypeCheckInspection(),
@@ -82,6 +89,18 @@ class Options{};
 assert(${'$'}options instanceof Options);
 class Options{};
                 """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testGenericAssertion() {
+        assert(
+            VirtualTypeCheckInspection(),
+            """<?php
+                class ListOfUsers{}
+                class User{}
+                /** @var ${'$'}user \ListOfUsers<User> */;
+                """
         )
     }
 

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/virtualTypeCheck/VirtualTypeCheckInspectionTest.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/virtualTypeCheck/VirtualTypeCheckInspectionTest.kt
@@ -7,19 +7,20 @@ class VirtualTypeCheckInspectionTest : BaseInspectionTest() {
     @Test
     fun testUseAssert() {
         assert(
-                VirtualTypeCheckInspection(),
-                """<?php
+            VirtualTypeCheckInspection(),
+            """<?php
                 class User{}
                 /** @var ${'$'}user <warning descr="Use assert to check variable type">User</warning> */;
                 assert(${'$'}user instanceof User); // Valid
                 """
         )
     }
+
     @Test
     fun testUseAssertWithInterface() {
         assert(
-                VirtualTypeCheckInspection(),
-                """<?php
+            VirtualTypeCheckInspection(),
+            """<?php
                 interface User{}
                 /** @var ${'$'}user <warning descr="Use assert to check variable type">User</warning> */;
                 assert(${'$'}user instanceof User); // Valid
@@ -30,18 +31,19 @@ class VirtualTypeCheckInspectionTest : BaseInspectionTest() {
     @Test
     fun testIgnoreArray() {
         assert(
-                VirtualTypeCheckInspection(),
-                """<?php
+            VirtualTypeCheckInspection(),
+            """<?php
                 /** @var ${'$'}user[] user */;
                 /** @var ${'$'}user stdClass[] */;
                 """
         )
     }
+
     @Test
     fun testSkipPrimitiveTypes() {
         assert(
-                VirtualTypeCheckInspection(),
-                """<?php
+            VirtualTypeCheckInspection(),
+            """<?php
                 /** @var ${'$'}user string */;
                 /** @var ${'$'}user int */;
                 /** @var ${'$'}user resource */;
@@ -55,8 +57,8 @@ class VirtualTypeCheckInspectionTest : BaseInspectionTest() {
     @Test
     fun testUnionType() {
         assert(
-                VirtualTypeCheckInspection(),
-                """<?php
+            VirtualTypeCheckInspection(),
+            """<?php
                 /** @var ${'$'}user string|null */;
                 /** @var ${'$'}user stdClass|int */;
                 """
@@ -66,8 +68,8 @@ class VirtualTypeCheckInspectionTest : BaseInspectionTest() {
     @Test
     fun testFunctionParam() {
         assert(
-                VirtualTypeCheckInspection(),
-                """<?php
+            VirtualTypeCheckInspection(),
+            """<?php
                 class Options{}
                 /** @param ${'$'}options Options */
                 function show(${'$'}options){
@@ -80,12 +82,12 @@ class VirtualTypeCheckInspectionTest : BaseInspectionTest() {
     @Test
     fun testReverseFormat() {
         assert(
-                VirtualTypeCheckInspection(),
-                """<?php
+            VirtualTypeCheckInspection(),
+            """<?php
 /** @var <warning descr="Use assert to check variable type">Options</warning> ${'$'}options */
 class Options{};
                 """.trimIndent(),
-                """<?php
+            """<?php
 assert(${'$'}options instanceof Options);
 class Options{};
                 """.trimIndent()


### PR DESCRIPTION
It is not possible to use `assert` for generic types
```php
class ListOfUsers{}
class User{}
/** @var $user \ListOfUsers<User> */;

```
Fixes #156