### PR TITLE
Skip some online tests when in `./gradlew test --offline` mode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,6 +121,11 @@ tasks {
     named("runIde") {
         dependsOn("copyInspections")
     }
+
+    // Network-sensitive tasks: run ONLY when not offline
+    matching { name in listOf("publishPlugin", "runPluginVerifier") }.configureEach {
+        onlyIf { !gradle.startParameter.isOffline }
+    }
 }
 tasks.getByName("buildSearchableOptions").onlyIf { false }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,7 +122,9 @@ tasks {
         dependsOn("copyInspections")
     }
 
-    // Network-sensitive tasks: run ONLY when not offline
+    // Network-sensitive tasks: run ONLY when not in --offline mode
+    // You'll probaly need to prime your caches during an online phase, using a command such as:
+    // ./gradlew help --refresh-dependencies --no-daemon
     matching { name in listOf("publishPlugin", "runPluginVerifier") }.configureEach {
         onlyIf { !gradle.startParameter.isOffline }
     }


### PR DESCRIPTION
Context: Bumped into issues running the tests in OpenAI Codex' offline VM. Skips publishPlugin and runPluginVerifier in `--ofline` mode. Probably useful in some other context as well.

Otherwise, you can turn on internet access of the VM. Testing works with the 'GET, HEAD and OPTIONS' HTTP-method filter enabled.

For reference, here is the 'environment' (VM) configuration script I'm using. Upgrades Gradle to 8.4 so it runs under Java 21 that they include. Also runs a bunch of commands that should retrieve and cache all dependencies.

```
#!/usr/bin/env bash

set -euo pipefail

# Update Gradle wrapper to version 8.4
sed -i.bak 's|distributionUrl=.*gradle-[^/]*-all.zip|distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip|' ./gradle/wrapper/gradle-wrapper.properties

# Refresh dependencies (probably duplicates efforts)
./gradlew compileKotlin
./gradlew dependencies --refresh-dependencies
./gradlew test --refresh-dependencies
# ./gradlew test --offline
# ./gradlew buildPlugin
./gradlew help --refresh-dependencies --no-daemon

# Add note about offline testing to AGENTS.md
echo -e '\nIf you have no internet, you have to use `./gradlew test --offline` to run the tests.' >> AGENTS.md
```