### PR TITLE
Spurious deprecated to string call (issue #212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- Keep a Changelog guide -> https://keepachangelog.com -->
 
 # PhpClean Changelog
+## [Unreleased]
+### Fixed
+- #212 Spurious "Deprecated __toString call" warning on cast of a method call result, e.g. `(string)$another->returnsBlaFoo();`
+
 ## [2023.12.17]
 ### Fixed
 - #186 RedundantDocCommentTagInspection - Skip checking array shapes 

--- a/src/main/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspection.kt
+++ b/src/main/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspection.kt
@@ -25,6 +25,13 @@ class ToStringCallInspection : PhpCleanInspection() {
         return object : PhpElementVisitor() {
             override fun visitPhpVariable(variable: Variable) {
                 if (context.match(variable.parent)) {
+                    if (variable.parent is UnaryExpression) {
+                        val unary = variable.parent as UnaryExpression
+                        val parent = unary.parent
+                        if (parent is MethodReference && parent.classReference == unary) {
+                            return
+                        }
+                    }
                     if (IsSingleClassType().match(variable)) {
                         holder.registerProblem(
                                 variable,
@@ -51,6 +58,9 @@ class ToStringCallInspection : PhpCleanInspection() {
             }
 
             override fun visitPhpMethodReference(reference: MethodReference) {
+                if (reference.parent is UnaryExpression && reference.classReference is Variable) {
+                    return
+                }
                 if (context.match(reference.parent)) {
                     val resolve = reference.resolve()
                     if (resolve is Function && resolve.name != "__toString") {

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallIssue212Test.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallIssue212Test.kt
@@ -24,8 +24,9 @@ class ToStringCallIssue212Test : BaseInspectionTest() {
                         }
                     }
                     ${'$'}another = new Another();
-                    (string)(${ '$'}another->returnsBlaFoo());
+                    (string)(${'$'}another->returnsBlaFoo());
                     (string)${'$'}another->returnsBlaFoo();
+            """
         )
     }
 }

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallIssue212Test.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallIssue212Test.kt
@@ -1,0 +1,31 @@
+package com.funivan.idea.phpClean.inspections.toStringCall
+
+import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
+
+class ToStringCallIssue212Test : BaseInspectionTest() {
+    @Test
+    fun testCastFunctionCallFromObject() {
+        assert(
+            ToStringCallInspection(),
+            """
+                    <?php
+                    class BlaFoo {
+                        public function __toString(): string {
+                            return 'BlaFoo';
+                        }
+                    }
+                    class Another {
+                        public function returnsBlaFoo(): BlaFoo {
+                            return new BlaFoo();
+                        }
+                        public function __toString(): string {
+                            return '';
+                        }
+                    }
+                    ${'$'}another = new Another();
+                    (string)(${ '$'}another->returnsBlaFoo());
+                    (string)${'$'}another->returnsBlaFoo();
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes cast detection for method calls in `ToStringCallInspection` so `(string)$another->returnsBlaFoo();` is not incorrectly flagged as a deprecated `__toString` call.
- Adds a regression test covering this case.

Recreated from #213 (originally by @HenkPoley) under my own account.

## Test plan
- [x] `./gradlew test`