### PR TITLE
ToStringCallInspection: report parenthesized casts + "Ignore classes with __toString" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <!-- Keep a Changelog guide -> https://keepachangelog.com -->
 
 # PhpClean Changelog
+## [Unreleased]
+### Fixed
+- #212 ToStringCallInspection - Report casts wrapped in redundant parentheses, e.g. `(string)($object->method())`
+### Added
+- ToStringCallInspection - New "Ignore classes with __toString" option to skip values whose class provides `__toString()`
+
 ## [2023.12.17]
 ### Fixed
 - #186 RedundantDocCommentTagInspection - Skip checking array shapes 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- Keep a Changelog guide -> https://keepachangelog.com -->
 
 # PhpClean Changelog
-## [Unreleased]
+## [2026.08.30]
 ### Fixed
 - #212 ToStringCallInspection - Report casts wrapped in redundant parentheses, e.g. `(string)($object->method())`
 ### Added

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ class Hello {
 }
 echo (new Hello())->randomize(); // <-- Deprecated __toString call
 ```
+Redundant parentheses do not change what is cast, so both lines below report the same call:
+```php
+(string)$hello->randomize();
+(string)($hello->randomize());
+```
+Enable the "Ignore classes with __toString" option to skip values whose class provides a __toString() method.
 #### VirtualTypeCheck
 Use assert to check variable type instead of doc comment.
 ```php

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 pluginGroup = com.funivan.idea.phpClean
 pluginName_ = PhpClean
 name = PhpClean
-pluginVersion = 2023.12.17
+pluginVersion = 2026.08.30
 pluginSinceBuild = 2022.2.3
 #pluginUntilBuild = 203.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl

--- a/src/main/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/HasToStringMethod.kt
+++ b/src/main/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/HasToStringMethod.kt
@@ -1,0 +1,20 @@
+package com.funivan.idea.phpClean.inspections.toStringCall
+
+import com.funivan.idea.phpClean.constrains.ConstrainInterface
+import com.intellij.openapi.project.Project
+import com.jetbrains.php.PhpIndex
+import com.jetbrains.php.lang.psi.resolve.types.PhpType
+
+
+/**
+ * Matches when the type resolves to at least one class and every resolved class provides __toString().
+ */
+class HasToStringMethod(private val project: Project) : ConstrainInterface<PhpType> {
+    override fun match(target: PhpType): Boolean {
+        val index = PhpIndex.getInstance(project)
+        val classes = target.global(project).types
+                .filterNot { PhpType.isPrimitiveType(it) }
+                .flatMap { index.getAnyByFQN(it) }
+        return classes.isNotEmpty() && classes.all { it.findMethodByName("__toString") != null }
+    }
+}

--- a/src/main/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspection.html
+++ b/src/main/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspection.html
@@ -6,4 +6,10 @@ class Hello {
 }
 echo (new Hello())->randomize(); // <-- Deprecated __toString call
 </pre>
+Redundant parentheses do not change what is cast, so both lines below report the same call:
+<pre>
+(string)$hello->randomize();
+(string)($hello->randomize());
+</pre>
+Enable the "Ignore classes with __toString" option to skip values whose class provides a __toString() method.
 <!-- main -->

--- a/src/main/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspection.kt
+++ b/src/main/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspection.kt
@@ -3,14 +3,20 @@ package com.funivan.idea.phpClean.inspections.toStringCall
 import com.funivan.idea.phpClean.spl.PhpCleanInspection
 import com.funivan.idea.phpClean.spl.Pointer
 import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.codeInspection.ui.SingleCheckboxOptionsPanel
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import com.jetbrains.php.lang.psi.elements.*
 import com.jetbrains.php.lang.psi.elements.Function
 import com.jetbrains.php.lang.psi.resolve.types.PhpType
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor
+import javax.swing.JComponent
 
 
 class ToStringCallInspection : PhpCleanInspection() {
+    @JvmField
+    var ignoreClassesWithToString = false
+
     val context = IsToStringContext()
     val safeCastTypes = lazy {
         PhpType.builder()
@@ -21,50 +27,87 @@ class ToStringCallInspection : PhpCleanInspection() {
     }
 
     override fun getShortName() = "ToStringCallInspection"
+
+    override fun createOptionsPanel(): JComponent {
+        return SingleCheckboxOptionsPanel(
+                "Ignore classes with __toString",
+                this,
+                "ignoreClassesWithToString"
+        )
+    }
+
+    /**
+     * Redundant parentheses do not change what gets cast, so they must not hide the call:
+     * `(string)($o->m())` means exactly the same as `(string)$o->m()`.
+     */
+    private fun isCastContext(element: PsiElement): Boolean {
+        var parent = element.parent
+        while (parent is ParenthesizedExpression) {
+            parent = parent.parent
+        }
+        return parent != null && context.match(parent)
+    }
+
+    private fun ignored(type: PhpType, element: PsiElement): Boolean {
+        return ignoreClassesWithToString && HasToStringMethod(element.project).match(type)
+    }
+
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
         return object : PhpElementVisitor() {
             override fun visitPhpVariable(variable: Variable) {
-                if (context.match(variable.parent)) {
-                    if (IsSingleClassType().match(variable)) {
-                        holder.registerProblem(
-                                variable,
-                                "Deprecated __toString call",
-                                AddToStringCallQF(
-                                        Pointer(variable as PhpPsiElement).create()
-                                )
-                        )
-                    }
+                if (!isCastContext(variable)) {
+                    return
                 }
+                if (!IsSingleClassType().match(variable)) {
+                    return
+                }
+                if (ignored(variable.type, variable)) {
+                    return
+                }
+                holder.registerProblem(
+                        variable,
+                        "Deprecated __toString call",
+                        AddToStringCallQF(
+                                Pointer(variable as PhpPsiElement).create()
+                        )
+                )
             }
 
             override fun visitPhpNewExpression(expression: NewExpression) {
-                val parent = expression.parent
-                if (context.match(parent)) {
-                    holder.registerProblem(
-                            expression,
-                            "Deprecated __toString call",
-                            AddToStringCallQF(
-                                    Pointer(expression as PhpPsiElement).create()
-                            )
-                    )
+                if (!isCastContext(expression)) {
+                    return
                 }
+                if (ignored(expression.type, expression)) {
+                    return
+                }
+                holder.registerProblem(
+                        expression,
+                        "Deprecated __toString call",
+                        AddToStringCallQF(
+                                Pointer(expression as PhpPsiElement).create()
+                        )
+                )
             }
 
             override fun visitPhpMethodReference(reference: MethodReference) {
-                if (context.match(reference.parent)) {
-                    val resolve = reference.resolve()
-                    if (resolve is Function && resolve.name != "__toString") {
-                        val declaredType = resolve.declaredType
-                        val types = declaredType.filter(safeCastTypes.value)
-                        if (!types.isEmpty) {
-                            holder.registerProblem(
+                if (!isCastContext(reference)) {
+                    return
+                }
+                val resolve = reference.resolve()
+                if (resolve is Function && resolve.name != "__toString") {
+                    val declaredType = resolve.declaredType
+                    val types = declaredType.filter(safeCastTypes.value)
+                    if (!types.isEmpty) {
+                        if (ignored(types, reference)) {
+                            return
+                        }
+                        holder.registerProblem(
                                 reference,
                                 "Deprecated __toString call",
                                 AddToStringCallQF(
-                                    Pointer(reference as PhpPsiElement).create()
+                                        Pointer(reference as PhpPsiElement).create()
                                 )
-                            )
-                        }
+                        )
                     }
                 }
             }

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspectionTestIgnoreToString.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspectionTestIgnoreToString.kt
@@ -1,0 +1,125 @@
+package com.funivan.idea.phpClean.inspections.toStringCall
+
+import com.funivan.idea.phpClean.BaseInspectionTest
+import org.jdom.Element
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * "Ignore classes with __toString" option. Off by default; when on, casting a value
+ * whose class provides __toString() is not reported.
+ */
+class ToStringCallInspectionTestIgnoreToString : BaseInspectionTest() {
+
+    private fun inspection(ignore: Boolean) = ToStringCallInspection().also {
+        it.ignoreClassesWithToString = ignore
+    }
+
+    @Test
+    fun testOptionIsDisabledByDefault() {
+        assert(
+            ToStringCallInspection(),
+            """<?php
+class Hello {
+    public function __toString(): string { return 'Hi'; }
+}
+${'$'}phrase = new Hello();
+(string)<warning descr="Deprecated __toString call">${'$'}phrase</warning>;
+"""
+        )
+    }
+
+    @Test
+    fun testVariableIgnoredWhenClassHasToString() {
+        assert(
+            inspection(true),
+            """<?php
+class Hello {
+    public function __toString(): string { return 'Hi'; }
+}
+${'$'}phrase = new Hello();
+(string)${'$'}phrase;
+echo ${'$'}phrase;
+"""
+        )
+    }
+
+    @Test
+    fun testNewExpressionIgnoredWhenClassHasToString() {
+        assert(
+            inspection(true),
+            """<?php
+class Hello {
+    public function __toString(): string { return 'Hi'; }
+}
+(string)new Hello();
+"""
+        )
+    }
+
+    @Test
+    fun testMethodCallIgnoredWhenReturnedClassHasToString() {
+        assert(
+            inspection(true),
+            """<?php
+class BlaFoo {
+    public function __toString(): string { return 'BlaFoo'; }
+}
+class Another {
+    public function returnsBlaFoo(): BlaFoo { return new BlaFoo(); }
+}
+${'$'}another = new Another();
+(string)${'$'}another->returnsBlaFoo();
+(string)(${'$'}another->returnsBlaFoo());
+"""
+        )
+    }
+
+    @Test
+    fun testStillReportedWhenClassHasNoToString() {
+        assert(
+            inspection(true),
+            """<?php
+class NoCast {
+}
+class Another {
+    public function returnsNoCast(): NoCast { return new NoCast(); }
+}
+${'$'}another = new Another();
+${'$'}plain = new NoCast();
+(string)<warning descr="Deprecated __toString call">${'$'}plain</warning>;
+(string)<warning descr="Deprecated __toString call">${'$'}another->returnsNoCast()</warning>;
+"""
+        )
+    }
+
+    @Test
+    fun testOptionSurvivesProfileRoundTrip() {
+        val saved = ToStringCallInspection()
+        saved.ignoreClassesWithToString = true
+        val element = Element("inspection")
+        saved.writeSettings(element)
+
+        val restored = ToStringCallInspection()
+        assertFalse(restored.ignoreClassesWithToString)
+        restored.readSettings(element)
+        assertTrue(restored.ignoreClassesWithToString, "option must be persisted in the inspection profile")
+    }
+
+    @Test
+    fun testInheritedToStringIsIgnored() {
+        assert(
+            inspection(true),
+            """<?php
+class Base {
+    public function __toString(): string { return 'base'; }
+}
+class Child extends Base {
+}
+${'$'}child = new Child();
+(string)${'$'}child;
+"""
+        )
+    }
+}

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspectionTestIssue212.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspectionTestIssue212.kt
@@ -1,0 +1,50 @@
+package com.funivan.idea.phpClean.inspections.toStringCall
+
+import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
+
+/**
+ * Snippet from issue #212.
+ *
+ * `(string)$another->returnsBlaFoo()` casts the RETURNED BlaFoo, not `$another`,
+ * so the report belongs on the method call. `((string)$another)->returnsBlaFoo()`
+ * is a different expression and is reported on the variable.
+ */
+class ToStringCallInspectionTestIssue212 : BaseInspectionTest() {
+    @Test
+    fun testIssue212Snippet() {
+        assert(
+            ToStringCallInspection(),
+            """<?php
+declare(strict_types=1);
+
+class BlaFoo
+{
+    public function __toString(): string
+    {
+        return 'BlaFoo';
+    }
+}
+
+class Another {
+    public function returnsBlaFoo(): BlaFoo {
+        return new BlaFoo();
+    }
+
+    public function __toString(): string
+    {
+        return '';
+    }
+}
+
+${'$'}another = new Another();
+
+(string)(<warning descr="Deprecated __toString call">${'$'}another->returnsBlaFoo()</warning>);
+
+(string)<warning descr="Deprecated __toString call">${'$'}another->returnsBlaFoo()</warning>;
+
+((string)<warning descr="Deprecated __toString call">${'$'}another</warning>)->returnsBlaFoo();
+"""
+        )
+    }
+}

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspectionTestParenthesized.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspectionTestParenthesized.kt
@@ -1,0 +1,60 @@
+package com.funivan.idea.phpClean.inspections.toStringCall
+
+import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
+
+/**
+ * Redundant parentheses must not hide the implicit __toString call.
+ * `(string)($o->m())` is the same expression as `(string)$o->m()`.
+ */
+class ToStringCallInspectionTestParenthesized : BaseInspectionTest() {
+
+    @Test
+    fun testParenthesizedMethodCall() {
+        assert(
+            ToStringCallInspection(),
+            """<?php
+class BlaFoo {
+    public function __toString(): string { return 'BlaFoo'; }
+}
+class Another {
+    public function returnsBlaFoo(): BlaFoo { return new BlaFoo(); }
+}
+${'$'}another = new Another();
+(string)(<warning descr="Deprecated __toString call">${'$'}another->returnsBlaFoo()</warning>);
+(string)<warning descr="Deprecated __toString call">${'$'}another->returnsBlaFoo()</warning>;
+(string)((<warning descr="Deprecated __toString call">${'$'}another->returnsBlaFoo()</warning>));
+"""
+        )
+    }
+
+    @Test
+    fun testParenthesizedVariable() {
+        assert(
+            ToStringCallInspection(),
+            """<?php
+class Hello {
+    public function __toString(): string { return 'Hi'; }
+}
+${'$'}phrase = new Hello();
+(string)(<warning descr="Deprecated __toString call">${'$'}phrase</warning>);
+echo (<warning descr="Deprecated __toString call">${'$'}phrase</warning>);
+"""
+        )
+    }
+
+    @Test
+    fun testParenthesizedScalarReturnStillClean() {
+        assert(
+            ToStringCallInspection(),
+            """<?php
+class Another {
+    public function returnsString(): string { return 'x'; }
+    public function __toString(): string { return ''; }
+}
+${'$'}another = new Another();
+(string)(${'$'}another->returnsString());
+"""
+        )
+    }
+}


### PR DESCRIPTION
## Fix: parenthesized casts were silently skipped

`IsToStringContext` matched on the element's direct parent. Wrapping parentheses produce a `ParenthesizedExpression` in between, so the context check failed and the call went unreported:

```php
(string)$another->returnsBlaFoo();    // reported
(string)($another->returnsBlaFoo());  // NOT reported (same expression!)
```

Both compile to the same thing — the parentheses are redundant and do not change what is cast. The cast context now walks past `ParenthesizedExpression`.

This is the one real defect in #212. Note it is a **false negative**, the opposite of what that issue reports: `(string)$object->method()` casts the *returned* object, not `$object`, so reporting it on the method call was already correct. Verified against PHP 8.4 — that expression calls `BlaFoo::__toString()`, never `Another::__toString()`, and emits no deprecation under `E_ALL`. `ToStringCallInspectionTestIssue212` pins all three lines from the issue.

## Feature: "Ignore classes with __toString" option

New checkbox on the inspection, **off by default**. When enabled, a value is not reported if its class provides `__toString()` (including inherited). Applies to variables, `new` expressions, and method return types.

## Notes

- `HasToStringMethod` resolves the type through `PhpIndex` and requires *every* resolved class to have `__toString()`, so union types are not silently ignored.
- Option is a `@JvmField` so it round-trips through the inspection profile; `testOptionSurvivesProfileRoundTrip` covers that.
- `README.md` regenerated via `./gradlew updateReadme`.

## Test plan

- [x] `./gradlew test` — 102 tests, 0 failures (11 new)
- [x] Behavior confirmed against unpatched `master` before/after