### PR TITLE
Fix since-build format and run verifyPlugin in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   push:
+  pull_request:
 jobs:
   test:
     name: Test
@@ -14,4 +15,4 @@ jobs:
 
       - uses: burrunan/gradle-cache-action@v1.5
         with:
-          arguments: check buildPlugin
+          arguments: check buildPlugin verifyPlugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ pluginGroup = com.funivan.idea.phpClean
 pluginName_ = PhpClean
 name = PhpClean
 pluginVersion = 2026.08.30
-pluginSinceBuild = 2022.2.3
+pluginSinceBuild = 222.4345
 #pluginUntilBuild = 203.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions


### PR DESCRIPTION
## What/Why?

`verifyPlugin` was failing:

```
Invalid plugin descriptor 'plugin.xml'. The <since-build> parameter (2022.2.3) does not
match the multi-part build number format <branch>.<build_number>.<version>
```

`pluginSinceBuild` in `gradle.properties` held a marketing version (`2022.2.3`) rather than an IDE build number. `patchPluginXml` copies that value straight into `plugin.xml`, so verification rejected the descriptor.

Set `pluginSinceBuild = 222.4345`, the 2022.2 branch build. It lines up with `platformVersion = 2022.2.3` and the pinned `com.jetbrains.php:222.4345.15`. `platformVersion` is unchanged: that property is a release name used to resolve the IDE dependency and is valid as-is.

Note the effective support floor changes. The committed `plugin.xml` declared `since-build="145.0"` (2016.1), which was never accurate given the 222-branch PHP plugin dependency. The patched value now reflects what the plugin actually runs on.

Second commit adds `verifyPlugin` to the test workflow so this fails in CI instead of at release time, and adds a `pull_request` trigger. The workflow previously ran `on: push` only, which skipped PRs from forks.

## Rollout/Rollback

Build configuration only, no runtime code change. Rollback is a revert of either commit; they are independent.

## Testing

```
JAVA_HOME=/opt/homebrew/opt/openjdk@17 ./gradlew verifyPlugin
```

Passes. The log confirms the patch applied:

```
[gradle-intellij-plugin :patchPluginXml] Patching plugin.xml: attribute
'since-build=[145.0]' of 'idea-version' tag will be set to '222.4345'
BUILD SUCCESSFUL
```

CI on this PR exercises the new `verifyPlugin` step directly.